### PR TITLE
Allow product creation from Bling stock webhook when import_product is enabled

### DIFF
--- a/functions/lib/bling-auth/create-axios.js
+++ b/functions/lib/bling-auth/create-axios.js
@@ -5,7 +5,7 @@ module.exports = (accessToken, clientId, clientSecret) => {
   }
 
   console.log('>>> Request with ', accessToken ? ` token: ${accessToken}` : 'Basic Auth', ` ${new Date().toISOString()}`)
-  const baseURL = 'https://www.bling.com.br/Api/v3'
+  const baseURL = 'https://api.bling.com.br/Api/v3'
   if (accessToken) {
     headers = {
       'Content-Type': 'application/json',

--- a/functions/lib/integration/import-product.js
+++ b/functions/lib/integration/import-product.js
@@ -29,13 +29,17 @@ const createUpdateProduct = async ({ appSdk, storeId, auth }, appData, sku, prod
           quantity += !Number.isNaN(saldo) ? saldo : 0
         }
       })
+      logger.info(`#${storeId} [STOCK_DEBUG] sku=${sku} has_stock_reserve=${appData.has_stock_reserve} calculatedQuantity=${quantity} fromDeposits=true`)
       blingItem.estoqueAtual = quantity
       delete blingItem.depositos
+    } else {
+      logger.info(`#${storeId} [STOCK_DEBUG] sku=${sku} estoqueAtual=${blingItem.estoqueAtual} hasDepositos=${Array.isArray(blingItem.depositos)} fromDeposits=false`)
     }
   })
 
   const blingProductFind = !variationId ? blingProduct : blingItems.find(item => item.codigo === sku)
   let quantity = Number(blingProductFind.estoqueAtual)
+  logger.info(`#${storeId} [STOCK_DEBUG] sku=${sku} finalQuantity=${quantity}`)
 
   if (product && (isStockOnly === true || !appData.update_product || variationId)) {
     if (!isNaN(quantity)) {
@@ -242,13 +246,16 @@ module.exports = async ({ appSdk, storeId, auth }, _blingStore, blingDeposit, qu
               const blingProductStoke = await bling.get(stokeEndpoint)
                 .then(({ data: { data } }) => data)
 
+              logger.info(`#${storeId} [STOCK_DEBUG] sku=${sku} blingProductId=${blingProductData?.id} stockResponse=${JSON.stringify(blingProductStoke)}`)
+
               if (blingProductData) {
                 if (blingProductStoke.length) {
                   const stokeProduct = blingProductStoke.find(stoke => stoke.produto.id === blingProductData.id)
                   if (stokeProduct) {
+                    logger.info(`#${storeId} [STOCK_DEBUG] sku=${sku} depositos=${JSON.stringify(stokeProduct.depositos)} saldoFisicoTotal=${stokeProduct.saldoFisicoTotal} saldoVirtualTotal=${stokeProduct.saldoVirtualTotal}`)
                     Object.assign(blingProductData, { depositos: stokeProduct.depositos })
                   }
-                  if (blingProductData.variacoes.length) {
+                  if (blingProductData.variacoes?.length) {
                     blingProductData.variacoes.forEach(variation => {
                       const stokeVariation = blingProductStoke.find(stoke => stoke.produto.id === variation.id)
                       if (stokeVariation) {

--- a/functions/routes/bling/callback.js
+++ b/functions/routes/bling/callback.js
@@ -2,15 +2,14 @@ const { Timestamp, getFirestore } = require('firebase-admin/firestore')
 const { logger } = require('../../context')
 const { nameCollectionEvents } = require('../../__env')
 const checkApiBling = require('../../lib/bling-auth/check-enable-api')
-// const getAppData = require('./../../lib/store-api/get-app-data')
+const getAppData = require('./../../lib/store-api/get-app-data')
 
 exports.post = async ({ appSdk, admin }, req, res) => {
   try {
     // const blingToken = req.query.token
     const storeId = parseInt(req.query.store_id, 10)
     if (storeId > 100 && req.body) {
-      await appSdk.getAuth(storeId)
-      // const appData = await getAppData({ appSdk, storeId, auth })
+      const auth = await appSdk.getAuth(storeId)
 
       const isApiBlingOk = await checkApiBling(storeId)
 
@@ -18,6 +17,8 @@ exports.post = async ({ appSdk, admin }, req, res) => {
         logger.warn('> Error in request to api Bling')
         return res.sendStatus(403)
       }
+
+      const appData = await getAppData({ appSdk, storeId, auth })
 
       logger.info(`storeId: ${storeId} ${JSON.stringify(req.body)}`)
 
@@ -71,7 +72,8 @@ exports.post = async ({ appSdk, admin }, req, res) => {
               ...body,
               resourceId,
               queue: 'skus',
-              _blingId: id
+              _blingId: id,
+              canCreateNew: appData.import_product === true
             }, { merge: true })
               .catch(logger.error)
             )


### PR DESCRIPTION
## Problema

Quando o Bling disparava um webhook de alteração de estoque para um produto
que ainda não existia na e-com.plus, o produto era sempre ignorado — mesmo
com a opção `import_product` ativada na configuração da loja.

O motivo era que o `callback.js` enfileirava o evento com `canCreateNew: false`
hardcoded, e na lógica de importação esse flag tinha precedência sobre o
`import_product`, impedindo a criação do produto independentemente da config.

## Solução

O `callback.js` agora carrega o `appData` da loja (após a validação da API
Bling, evitando chamadas desnecessárias) e define `canCreateNew` de forma
condicional para eventos de estoque:

- `import_product: true` → `canCreateNew: true` → produto é criado na e-com.plus
- `import_product: false` → `canCreateNew: false` → comportamento anterior mantido

Pedidos vindos do callback do Bling não são afetados e continuam com
`canCreateNew: false`.