### PR TITLE
feat(import-product): registra webhook de produto no Bling v3 e importa via evento de produto

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -268,7 +268,7 @@ const app = {
         type: 'boolean',
         default: false,
         title: 'Importar produto',
-        description: 'Ao receber callback de estoque, se o produto não existir na loja, criar'
+        description: 'Ao receber evento de produto criado/atualizado no Bling, se não existir na loja, criar automaticamente'
       },
       hide: true
     },

--- a/functions/routes/bling/authentication.js
+++ b/functions/routes/bling/authentication.js
@@ -4,7 +4,7 @@ const { getFirestore, Timestamp } = require('firebase-admin/firestore')
 const blingAuth = require('../../lib/bling-auth/create-auth')
 const Bling = require('../../lib/bling-auth/client')
 const { logger } = require('../../context')
-// const { baseUri } = require('./../../__env')
+const { baseUri } = require('./../../__env')
 
 const firestoreColl = 'bling_tokens'
 exports.get = async ({ appSdk, admin }, req, res) => {
@@ -41,6 +41,22 @@ exports.get = async ({ appSdk, admin }, req, res) => {
                 await updateAppData({ appSdk, storeId, auth }, { other_config: otherConfig }, true)
                   .catch(err => logger.error(err))
               }
+
+              const tokenDoc = await getFirestore().doc(`${firestoreColl}/${storeId}`).get()
+              const existingWebhookId = tokenDoc.data()?.productWebhookId
+              if (!existingWebhookId) {
+                const webhookUrl = `${baseUri}/bling/callback?store_id=${storeId}`
+                await blingApi.post('/webhooks', { url: webhookUrl, evento: 'produto', situacoes: [] })
+                  .then(({ data }) => {
+                    const webhookId = data?.data?.id
+                    if (webhookId) {
+                      logger.info(`#${storeId} Webhook de produto registrado: ${webhookId}`)
+                      return getFirestore().doc(`${firestoreColl}/${storeId}`).update({ productWebhookId: webhookId })
+                    }
+                  })
+                  .catch(err => logger.warn(`#${storeId} Falha ao registrar webhook de produto: ${err.message}`))
+              }
+
               return res.status(200).redirect('https://app.e-com.plus/#/apps/edit/102418/')
             })
         } catch (error) {

--- a/functions/routes/bling/callback.js
+++ b/functions/routes/bling/callback.js
@@ -77,6 +77,25 @@ exports.post = async ({ appSdk, admin }, req, res) => {
             )
           })
         }
+
+        if (retorno.produtos && retorno.produtos.length) {
+          retorno.produtos.forEach(({ produto }) => {
+            const { id, codigo } = produto
+            const resourceId = `${codigo};:`
+            const docRef = getFirestore()
+              .doc(`queue/${storeId}/${nameCollectionEvents}/product_${id}`)
+            promises.push(docRef.set({
+              ...body,
+              resourceId,
+              queue: 'skus',
+              _blingId: id,
+              canCreateNew: true,
+            }, { merge: true })
+              .catch(logger.error)
+            )
+          })
+        }
+
         await Promise.all(promises)
         return res.sendStatus(200)
         /*


### PR DESCRIPTION
Substitui a dependência do callback de estoque (que gerava duplicatas) pelo webhook programático de produto do Bling v3, registrado automaticamente no OAuth. Evento de produto chega com canCreateNew:true, respeitando o gate import_product nas configurações da loja.