### PR TITLE
fix: usa urlRastreamento do webhook quando o GET do Bling não traz

### DIFF
--- a/functions/lib/events/handle-events.js
+++ b/functions/lib/events/handle-events.js
@@ -39,7 +39,9 @@ const handleEvents = async (event) => {
       canCreateNew,
       mustUpdateAppQueue,
       isHiddenQueue,
-      _blingId
+      _blingId,
+      webhookTransporte,
+      webhookCodigosRastreamento
     } = data
 
     const appSdk = await getAppSdk()
@@ -51,7 +53,7 @@ const handleEvents = async (event) => {
       const blingDeposit = appData.bling_deposit
 
       const handler = integrationHandlers[action][queue.toLowerCase()]
-      const queueEntry = { action, queue, nextId: resourceId, mustUpdateAppQueue, isHiddenQueue }
+      const queueEntry = { action, queue, nextId: resourceId, mustUpdateAppQueue, isHiddenQueue, webhookTransporte, webhookCodigosRastreamento }
       /*
         In some cases when importing products, Bling returns an empty list when searching for the SKU
         (which appears to be a bug in the Bling API, as it is a webhook event from Bling itself).

--- a/functions/lib/integration/import-order.js
+++ b/functions/lib/integration/import-order.js
@@ -13,6 +13,39 @@ const getLastStatus = records => {
   return statusRecord && statusRecord.status
 }
 
+/*
+  `GET /pedidos/vendas/{id}` never returns `urlRastreamento` on the volume objects,
+  only `codigoRastreamento` -- the Bling webhook payload does include it. Fill it in
+  from the webhook data (saved on the queue entry) when the fresher API fetch lacks it.
+*/
+const mergeWebhookTracking = (blingOrder, webhookTransporte, webhookCodigosRastreamento) => {
+  if (webhookTransporte && webhookTransporte.volumes && blingOrder.transporte && blingOrder.transporte.volumes) {
+    blingOrder.transporte.volumes.forEach((entry, i) => {
+      const volume = entry.volume || entry
+      if (volume.urlRastreamento) {
+        return
+      }
+      const webhookEntry = webhookTransporte.volumes[i]
+      const webhookVolume = webhookEntry && (webhookEntry.volume || webhookEntry)
+      if (
+        webhookVolume &&
+        webhookVolume.urlRastreamento &&
+        (!volume.codigoRastreamento || volume.codigoRastreamento === webhookVolume.codigoRastreamento)
+      ) {
+        volume.urlRastreamento = webhookVolume.urlRastreamento
+      }
+    })
+  }
+  if (
+    webhookCodigosRastreamento &&
+    blingOrder.codigosRastreamento &&
+    !blingOrder.codigosRastreamento.urlRastreamento &&
+    webhookCodigosRastreamento.urlRastreamento
+  ) {
+    blingOrder.codigosRastreamento.urlRastreamento = webhookCodigosRastreamento.urlRastreamento
+  }
+}
+
 module.exports = async ({ appSdk, storeId, auth }, _blingStore, _blingDeposit, queueEntry, appData) => {
   const blingOrderNumber = queueEntry.nextId
   const {
@@ -30,6 +63,7 @@ module.exports = async ({ appSdk, storeId, auth }, _blingStore, _blingDeposit, q
     .then(async ({ data: { data } }) => {
       logger.info(`order :${JSON.stringify(data)}`)
       const blingOrder = data
+      mergeWebhookTracking(blingOrder, queueEntry.webhookTransporte, queueEntry.webhookCodigosRastreamento)
 
       logger.info(`#${storeId} found order ${blingOrder.numero}`)
 

--- a/functions/routes/bling/callback.js
+++ b/functions/routes/bling/callback.js
@@ -46,12 +46,20 @@ exports.post = async ({ appSdk, admin }, req, res) => {
         if (retorno.pedidos && retorno.pedidos.length) {
           retorno.pedidos.forEach(({ pedido }) => {
             console.log(`${JSON.stringify(pedido)}`)
-            const { numero } = pedido
+            const { numero, transporte, codigosRastreamento } = pedido
             const resourceId = `${numero}`
             const docRef = getFirestore()
               .doc(`queue/${storeId}/${nameCollectionEvents}/order_${numero}`)
+            const trackingData = {}
+            if (transporte) {
+              trackingData.webhookTransporte = transporte
+            }
+            if (codigosRastreamento) {
+              trackingData.webhookCodigosRastreamento = codigosRastreamento
+            }
             promises.push(docRef.set({
               ...body,
+              ...trackingData,
               resourceId,
               queue: 'order_numbers',
               _blingId: numero


### PR DESCRIPTION
## Problema
Pedidos sincronizados do Bling ficavam com o link de rastreio errado (`melhorrastreio.com.br`) em vez do link real do transportador.

## Causa raiz
`GET /pedidos/vendas/{id}` (usado por `import-order.js`) **nunca** retorna `urlRastreamento` no volume de transporte — confirmado em 471 amostras reais dos últimos 30 dias, 0 com o campo preenchido. Só retorna `codigoRastreamento`.

O **webhook** do Bling (`POST /bling/callback`), por outro lado, traz `urlRastreamento` normalmente quando o rastreio já foi gerado (confirmado em múltiplos pedidos/lojas/transportadoras). Nosso código recebia o webhook só para saber "o quê" reprocessar, e descartava o corpo dele — sempre dependendo do GET mais pobre em dados.

> Nota: o fix que impedia o link travar para sempre (`order-to-ecomplus/index.js`) já foi mesclado no master em `8938c01`. Este PR complementa aquele fix, entregando o dado (o link real) que ele precisa pra ter efeito na prática — sem isso, o link provisório nunca tinha uma fonte melhor pra ser atualizado.

## O que muda neste PR

- **`callback.js`**: guarda `transporte`/`codigosRastreamento` do webhook no documento da fila, junto com o número do pedido.
- **`handle-events.js`**: repassa esses dados salvos pro `queueEntry` que vai pro handler.
- **`import-order.js`**: nova função `mergeWebhookTracking` — antes de processar o pedido, completa a `urlRastreamento` que faltou no GET usando o dado salvo do webhook, só quando o código de rastreio bate (evita misturar dado de pedidos diferentes).

## Testes
18 cenários cobertos com scripts ad-hoc (o projeto não tem suite automatizada), incluindo:
- Reprodução exata de 2 pedidos reais (14236 e 14252) com os dados encontrados nos logs
- Teste de ponta a ponta simulando o fluxo completo (merge do webhook → parser já existente no master)
- Casos de borda: sem dado de webhook, código diferente entre fontes, múltiplos volumes, template vazio do Bling, sem quebrar em nenhum caso testado
- Regressão do parser já mesclado (`8938c01`), confirmando que continua funcionando igual depois desta mudança

## Importante
O dado do webhook só passa a ser salvo a partir do deploy. Pedidos cujo webhook já foi recebido antes do deploy não têm esse dado guardado — vão continuar com o link provisório até o Bling mandar um novo evento pra eles (próxima mudança de status, nova nota fiscal etc.).

## Escopo
Só as mudanças relacionadas ao link de rastreio, rebaseado sobre o master atual (já inclui `8938c01`, `f4a01ba`, `1c9173a` etc.). Não inclui nenhuma mudança não relacionada ao assunto.